### PR TITLE
solve syntax error in colors config. (add semikolons)

### DIFF
--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -1,7 +1,7 @@
 // Define variables for your color scheme
-$title: #1FA5C9
-$subtitle: #4CBBC6
-$footnote: #81DAEB
+$title: #1FA5C9;
+$subtitle: #4CBBC6;
+$footnote: #81DAEB;
 // For example:
 $red: #FD1015;
 $blue: #167FFB;


### PR DESCRIPTION
semikolons were missing after color variable definition