### PR TITLE
switching back to authentication in application controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
   include Pundit
 
   # Pundit: white-list approach.


### PR DESCRIPTION
switching back to authentication in application controller
```before_action :authenticate_user!```

=> Will need to use the user email and password in the seed file to sign in
